### PR TITLE
robot-state-publisher needed by ros/hydro

### DIFF
--- a/scripts/install_sot.sh
+++ b/scripts/install_sot.sh
@@ -348,10 +348,6 @@ create_local_db()
   fi
 
   if [ "${PRIVATE_URI}" != "" ]; then
-    if [ "$ROS_VERSION" != "electric" ]; then
-        inst_array[index]="install_ros_ws_package urdf_parser_py"
-        let "index= $index + 1"
-    fi
     inst_array[index]="install_ros_ws_package hrp2_14_description"
     let "index= $index + 1"
   fi


### PR DESCRIPTION
with ros/hydro it is needed to install robot-state-publisher 
