### PR TITLE
Uses standalone version of jrl_dynamics_urdf for groovy and hydro

### DIFF
--- a/scripts/install_sot.sh
+++ b/scripts/install_sot.sh
@@ -430,8 +430,14 @@ create_local_db()
   inst_array[index]="install_pkg $SRC_DIR/sot sot-pattern-generator ${STACK_OF_TASKS_URI} topic/python"
   let "index= $index + 1"
 
-  inst_array[index]="install_ros_ws_package jrl_dynamics_urdf"
-  let "index= $index + 1"
+  # In groovy and hydro, use the standalone version of jrl_dynamics_urdf
+  if [ "$ROS_VERSION" == "groovy" ] || [ "$ROS_VERSION" == "hydro" ]; then
+    inst_array[index]="install_pkg $SRC_DIR/jrl jrl_dynamics_urdf ${LAAS_URI}"
+    let "index= $index + 1"
+  else
+    inst_array[index]="install_ros_ws_package jrl_dynamics_urdf"
+    let "index= $index + 1"
+  fi
 
   inst_array[index]="install_ros_ws_package dynamic_graph_bridge_msgs"
   let "index= $index + 1"


### PR DESCRIPTION
This commit makes uses of the stand alone version of jrl_dynamics_urdf for both groovy and hydro.

Requires:
Merge of https://github.com/stack-of-tasks/dynamic_graph_bridge/pull/21
and corresponding update of redundant_manipulator_control

Makes https://github.com/laas/jrl_dynamics_urdf/pull/10 useless
